### PR TITLE
Change TextFiled Type for Lateral Student

### DIFF
--- a/lib/ui/login/login_page.dart
+++ b/lib/ui/login/login_page.dart
@@ -75,7 +75,7 @@ class _LoginPageState extends State<LoginPage> {
                     validator: (val) => val != null && val.isNotEmpty
                         ? null
                         : 'Invalid username',
-                    inputType: TextInputType.number,
+                    inputType: TextInputType.text,
                     decoration: InputDecoration(
                       labelText: 'Edumarshal Username',
                       border: OutlineInputBorder(),


### PR DESCRIPTION
UPDATE: 
keyboard input type number to text for username at Login Page because some alphabetic characters are required for lateral entry student.
e.g. my username is 2######D194 (# --> Integar Character)